### PR TITLE
Fix the warning about frozen string literal

### DIFF
--- a/lib/seed-do/runner.rb
+++ b/lib/seed-do/runner.rb
@@ -34,11 +34,11 @@ module SeedDo
 
         ActiveRecord::Base.transaction do
           open(filename) do |file|
-            chunked_ruby = ''
+            chunked_ruby = +''
             file.each_line do |line|
               if line == "# BREAK EVAL\n"
                 eval(chunked_ruby)
-                chunked_ruby = ''
+                chunked_ruby = +''
               else
                 chunked_ruby << line
               end

--- a/lib/seed-do/writer.rb
+++ b/lib/seed-do/writer.rb
@@ -67,7 +67,7 @@ module SeedDo
     def <<(seed)
       raise "You must add seeds inside a SeedDo::Writer#write block" unless @io
 
-      buffer = ''
+      buffer = +''
 
       if chunk_this_seed?
         buffer << seed_footer


### PR DESCRIPTION
With Ruby 3.4 or higher, enabling warnings shows the following message. I fixed it by explicitly marking the string as mutable to prevent the warning.

```
/Users/willnet/ghq/github.com/willnet/seed-do/lib/seed-do/runner.rb:43: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

ref: [Feature #20205: Enable `frozen_string_literal` by default - Ruby - Ruby Issue Tracking System](https://bugs.ruby-lang.org/issues/20205)