### PR TITLE
Delay the loading of ActiveRecord

### DIFF
--- a/lib/seed-do.rb
+++ b/lib/seed-do.rb
@@ -31,6 +31,6 @@ module SeedDo
 end
 
 # @public
-class ActiveRecord::Base
+ActiveSupport.on_load(:active_record) do
   extend SeedDo::ActiveRecordExtension
 end


### PR DESCRIPTION
Rails expects all extension gems to use ActiveSupport.on_load do ... end to defer loading components like ActiveRecord::Base. Loading them immediately can prevent configurations in config/initializers/*.rb from being applied properly.

ref: https://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html