### PR TITLE
Fix a deprecation warning about using `should`

### DIFF
--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -4,21 +4,21 @@ describe SeedDo::Runner do
   it "should seed data from Ruby and gzipped Ruby files in the given fixtures directory" do
     SeedDo.seed(File.dirname(__FILE__) + '/fixtures')
 
-    SeededModel.find(1).title.should == "Foo"
-    SeededModel.find(2).title.should == "Bar"
-    SeededModel.find(3).title.should == "Baz"
+    expect(SeededModel.find(1).title).to eq "Foo"
+    expect(SeededModel.find(2).title).to eq "Bar"
+    expect(SeededModel.find(3).title).to eq "Baz"
   end
 
   it "should seed only the data which matches the filter, if one is given" do
     SeedDo.seed(File.dirname(__FILE__) + '/fixtures', /_2/)
 
-    SeededModel.count.should == 1
-    SeededModel.find(2).title.should == "Bar"
+    expect(SeededModel.count).to eq 1
+    expect(SeededModel.find(2).title).to eq "Bar"
   end
 
   it "should use the SeedDo.fixtures_paths variable to determine where fixtures are" do
     SeedDo.fixture_paths = [File.dirname(__FILE__) + '/fixtures']
     SeedDo.seed
-    SeededModel.count.should == 3
+    expect(SeededModel.count).to eq 3
   end
 end

--- a/spec/seeder_spec.rb
+++ b/spec/seeder_spec.rb
@@ -20,12 +20,12 @@ describe SeedDo::Seeder do
     end
 
     bob = SeededModel.find_by_id(-2)
-    bob.first_name.should == "Bob"
-    bob.last_name.should == "Bobson"
+    expect(bob.first_name).to eq "Bob"
+    expect(bob.last_name).to eq "Bobson"
 
     if ENV['DB'] == 'postgresql'
       next_id = SeededModel.connection.execute("select nextval('seeded_models_id_seq')")
-      next_id[0]['nextval'].to_i.should == 11
+      expect(next_id[0]['nextval'].to_i).to eq 11
     end
   end
 
@@ -39,8 +39,8 @@ describe SeedDo::Seeder do
     end
 
     bob = SeededModel.find_by_id(5)
-    bob.first_name.should == "Bob"
-    bob.last_name.should == "Bobson"
+    expect(bob.first_name).to eq "Bob"
+    expect(bob.last_name).to eq "Bobson"
   end
 
   it "should be able to handle multiple constraints" do
@@ -50,7 +50,7 @@ describe SeedDo::Seeder do
       s.first_name = "Bob"
     end
 
-    SeededModel.count.should == 1
+    expect(SeededModel.count).to eq 1
 
     SeededModel.seed(:title, :login) do |s|
       s.login = "frank"
@@ -58,15 +58,15 @@ describe SeedDo::Seeder do
       s.first_name = "Frank"
     end
 
-    SeededModel.count.should == 2
+    expect(SeededModel.count).to eq 2
 
-    SeededModel.find_by_login("bob").first_name.should == "Bob"
+    expect(SeededModel.find_by_login("bob").first_name).to eq "Bob"
     SeededModel.seed(:title, :login) do |s|
       s.login = "bob"
       s.title = "Peon"
       s.first_name = "Steve"
     end
-    SeededModel.find_by_login("bob").first_name.should == "Steve"
+    expect(SeededModel.find_by_login("bob").first_name).to eq "Steve"
   end
 
   it "should be able to create models from an array of seed attributes" do
@@ -76,9 +76,9 @@ describe SeedDo::Seeder do
       {:login => "harry", :title => "Noble", :first_name => "Harry"}
     ])
 
-    SeededModel.find_by_login("bob").first_name.should == "Steve"
-    SeededModel.find_by_login("frank").first_name.should == "Francis"
-    SeededModel.find_by_login("harry").first_name.should == "Harry"
+    expect(SeededModel.find_by_login("bob").first_name).to eq "Steve"
+    expect(SeededModel.find_by_login("frank").first_name).to eq "Francis"
+    expect(SeededModel.find_by_login("harry").first_name).to eq "Harry"
   end
 
   it "should be able to create models from a list of seed attribute hashes at the end of the args" do
@@ -88,9 +88,9 @@ describe SeedDo::Seeder do
       {:login => "harry", :title => "Noble", :first_name => "Harry"}
     )
 
-    SeededModel.find_by_login("bob").first_name.should == "Steve"
-    SeededModel.find_by_login("frank").first_name.should == "Francis"
-    SeededModel.find_by_login("harry").first_name.should == "Harry"
+    expect(SeededModel.find_by_login("bob").first_name).to eq "Steve"
+    expect(SeededModel.find_by_login("frank").first_name).to eq "Francis"
+    expect(SeededModel.find_by_login("harry").first_name).to eq "Harry"
   end
 
   it "should update, not create, if constraints are met" do
@@ -111,8 +111,8 @@ describe SeedDo::Seeder do
     end
 
     bob = SeededModel.find_by_id(1)
-    bob.first_name.should == "Robert"
-    bob.last_name.should == "Bobson"
+    expect(bob.first_name).to eq "Robert"
+    expect(bob.last_name).to eq "Bobson"
   end
 
   it "should create but not update with seed_once" do
@@ -133,15 +133,15 @@ describe SeedDo::Seeder do
     end
 
     bob = SeededModel.find_by_id(1)
-    bob.first_name.should == "Bob"
-    bob.last_name.should == "Bobson"
+    expect(bob.first_name).to eq "Bob"
+    expect(bob.last_name).to eq "Bobson"
   end
 
   it "should default to an id constraint" do
     SeededModel.seed(:title => "Bla", :id => 1)
     SeededModel.seed(:title => "Foo", :id => 1)
 
-    SeededModel.find(1).title.should == "Foo"
+    expect(SeededModel.find(1).title).to eq "Foo"
   end
 
   it "should require that all constraints are defined" do

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -16,8 +16,8 @@ describe SeedDo::Writer do
     end
     load @file_name
 
-    SeededModel.find(1).title.should == "Mr"
-    SeededModel.find(2).title.should == "Dr"
+    expect(SeededModel.find(1).title).to eq "Mr"
+    expect(SeededModel.find(2).title).to eq "Dr"
   end
 
   it "should support chunking" do
@@ -28,8 +28,8 @@ describe SeedDo::Writer do
     end
     load @file_name
 
-    SeededModel.count.should == 3
-    File.read(@file_name).should include("# BREAK EVAL\n")
+    expect(SeededModel.count).to eq 3
+    expect(File.read(@file_name)).to include("# BREAK EVAL\n")
   end
 
   it "should support specifying the output to use 'seed_once' rather than 'seed'" do
@@ -40,6 +40,6 @@ describe SeedDo::Writer do
     end
     load @file_name
 
-    SeededModel.find(1).title.should == "Dr"
+    expect(SeededModel.find(1).title).to eq "Dr"
   end
 end


### PR DESCRIPTION
Fix a deprecation warning about using should that appeared when running tests.

```
Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /home/runner/work/seed-do/seed-do/spec/runner_spec.rb:7:in `block (2 levels) in <top (required)>'.

If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.
```

Use synvert to change `should` to `expect`

`synvert-ruby -r rspec/should_to_expect .`