### PR TITLE
Delete code related to `rails/protected_attributes`.

### DIFF
--- a/lib/seed-do/seeder.rb
+++ b/lib/seed-do/seeder.rb
@@ -64,13 +64,7 @@ module SeedDo
 
         puts " - #{@model_class} #{data.inspect}" unless @options[:quiet]
 
-        # Rails 3 or Rails 4 + rails/protected_attributes
-        if record.class.respond_to?(:protected_attributes) && record.class.respond_to?(:accessible_attributes)
-          record.assign_attributes(data,  :without_protection => true)
-        # Rails 4 without rails/protected_attributes
-        else
-          record.assign_attributes(data)
-        end
+        record.assign_attributes(data)
         record.save(:validate => false) || raise(ActiveRecord::RecordNotSaved, 'Record not saved!')
         record
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,6 @@ end
 
 class SeededModel < ActiveRecord::Base
   validates_presence_of :title
-  attr_protected :first_name if self.respond_to?(:protected_attributes)
   attr_accessor :fail_to_save
 
   before_save { throw(:abort) if fail_to_save }


### PR DESCRIPTION
`rails/protected_attributes` is a gem used with Rails versions below 5. Since `seed-do` now supports Rails 7.1 and above, it is no longer needed and has been removed.
