### PR TITLE
Consolidate gitignore files by moving spec/.gitignore to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Gemfile.lock
 .yardoc
 doc
 gemfiles/*.gemfile.lock
+*.sqlite3
+spec/seeded_models.rb

--- a/spec/.gitignore
+++ b/spec/.gitignore
@@ -1,3 +1,0 @@
-debug.log
-test.sqlite3
-seeded_models.rb


### PR DESCRIPTION
## Summary
This PR consolidates gitignore rules by moving patterns from `spec/.gitignore` to the root `.gitignore` file and removes the redundant `spec/.gitignore` file.

## Problem
Having multiple `.gitignore` files across the project can lead to:
- Fragmented ignore rule management
- Difficulty in understanding which files are ignored and where the rules are defined
- Potential maintenance overhead when updating ignore patterns

## Changes
- **Removed** `spec/.gitignore` file
- **Moved** the following patterns to root `.gitignore`:
  - `test.sqlite3` → expanded to `*.sqlite3` for broader coverage
  - `seeded_models.rb` → changed to `spec/seeded_models.rb` for more precise targeting
- **Note**: `debug.log` was already covered by the existing `*.log` pattern in root `.gitignore`

## Special Case: seeded_models.rb
The original `seeded_models.rb` pattern in `spec/.gitignore` was intended to ignore files generated during testing in `spec/writer_spec.rb`(https://github.com/willnet/seed-do/commit/45a7b84b937187b95996934712a78bcd0d98858c). However, this broad pattern was also incorrectly ignoring `spec/fixtures/seeded_models.rb`, which is a legitimate fixture file required by `runner_spec.rb` and should be tracked in the repository.

To fix this issue, the pattern has been changed from `seeded_models.rb` to `spec/seeded_models.rb`, ensuring that:
- Generated test files in the spec directory are properly ignored (as a safety net in case cleanup hooks fail)
- The fixture file `spec/fixtures/seeded_models.rb` remains tracked as intended

## Testing
Verified that all previously ignored files remain ignored after the consolidation:
- Test database files (`*.sqlite3`)
- Generated test files (`spec/seeded_models.rb`)
- Debug logs (`*.log`)
- **Important**: `spec/fixtures/seeded_models.rb` is now correctly tracked
